### PR TITLE
Feat: stage가 올라갈수록 정답과 오답의 색상 차이가 줄어듭니다

### DIFF
--- a/src/components/BoardWrap.tsx
+++ b/src/components/BoardWrap.tsx
@@ -23,6 +23,14 @@ function BoardWrap(props: BoardWrap) {
   );
 
   useEffect(() => {
+    if (stage === 1) {
+      setDifference(128);
+    } else {
+      setDifference((prevDifference) => {
+        if (prevDifference <= 1) return 1;
+        return prevDifference - 9;
+      });
+    }
     setNumberOfSquare(Math.pow(Math.round((stage + 0.5) / 2) + 1, 2));
 
     setColor(() => randomRGB());


### PR DESCRIPTION
### What is this PR? 🔍
stage가 올라갈 수록 정답과 오답의 색상차이를 줄어들게 했다.
최소차이가 1이 되면, 차이는 1로 유지된다.

### Issue
#12